### PR TITLE
Makefile: Make compiler configurable and use C++ instead of C compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+CXX=c++
+
 resolver: resolver.o dns.o
-	gcc -o resolver resolver.o dns.o -lstdc++ -lssl -lcrypto
+	$(CXX) -o resolver resolver.o dns.o -lssl -lcrypto
 
 resolver.o: resolver.cpp 
-	gcc -c resolver.cpp
+	$(CXX) -c resolver.cpp
 
 dns.o: dns.cpp dns.h
-	gcc -c dns.cpp
+	$(CXX) -c dns.cpp
 
 clean:
 	rm -rf ./*.o


### PR DESCRIPTION
Adds `CXX` varaible for use with alternative compilers such as Clang and use a
C++ compiler rather than a C compiler to avoid explicit linking of C++ standard
library.